### PR TITLE
Whitelist Koofr false positive

### DIFF
--- a/submit_here/click_me_to_edit/exclude_for_all.txt
+++ b/submit_here/click_me_to_edit/exclude_for_all.txt
@@ -1,0 +1,2 @@
+api.koofr.net
+koofr.net


### PR DESCRIPTION
koofr.net is alt domain of koofr.eu and is required to use koofr via webdav, mobile or desktop apps.

This domain was blocked by 1Hosts (Xtra).